### PR TITLE
Add CrossSiteLinker plugin

### DIFF
--- a/cross-site-linker/cross-site-linker.php
+++ b/cross-site-linker/cross-site-linker.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Plugin Name: CrossSiteLinker
+ * Description: Cross links posts across multiple WordPress sites. Provides API endpoint and Gutenberg UI for suggestions.
+ * Version: 0.1.0
+ * Author: Theafolayan
+ * License: GPL-2.0-or-later
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin constants.
+define( 'CSL_VERSION', '0.1.0' );
+define( 'CSL_PATH', plugin_dir_path( __FILE__ ) );
+define( 'CSL_URL', plugin_dir_url( __FILE__ ) );
+
+// Include required files.
+require_once CSL_PATH . 'inc/provider.php';
+require_once CSL_PATH . 'inc/settings.php';
+require_once CSL_PATH . 'inc/client.php';
+require_once CSL_PATH . 'inc/internal.php';
+
+/**
+ * Enqueue scripts for Gutenberg editor.
+ */
+function csl_enqueue_editor_assets() {
+    wp_enqueue_script(
+        'csl-editor',
+        CSL_URL . 'js/editor.js',
+        [ 'wp-edit-post', 'wp-data', 'wp-components', 'wp-element', 'wp-i18n', 'wp-api-fetch' ],
+        CSL_VERSION,
+        true
+    );
+    wp_enqueue_script(
+        'csl-contextual',
+        CSL_URL . 'js/contextual.js',
+        [ 'wp-edit-post', 'wp-data', 'wp-components', 'wp-element', 'wp-i18n', 'wp-api-fetch' ],
+        CSL_VERSION,
+        true
+    );
+}
+add_action( 'enqueue_block_editor_assets', 'csl_enqueue_editor_assets' );
+

--- a/cross-site-linker/inc/client.php
+++ b/cross-site-linker/inc/client.php
@@ -1,0 +1,69 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Fetch suggestions from all configured sites.
+ *
+ * @param string $keyword Keyword to search for.
+ * @return array Array of suggestions.
+ */
+function csl_get_cross_site_suggestions( $keyword ) {
+    $sites   = get_option( 'csl_sites', [] );
+    $results = [];
+
+    if ( empty( $sites ) ) {
+        return $results;
+    }
+
+    $requests = [];
+    foreach ( $sites as $site ) {
+        if ( empty( $site['url'] ) ) {
+            continue;
+        }
+        $url = trailingslashit( $site['url'] ) . 'wp-json/crosslinker/v1/posts?q=' . rawurlencode( $keyword );
+        $args = [
+            'timeout' => 5,
+        ];
+        if ( ! empty( $site['key'] ) ) {
+            $args['headers'] = [ 'X-API-KEY' => $site['key'] ];
+        }
+        $requests[] = [ 'url' => $url, 'args' => $args ];
+    }
+
+    // Perform requests sequentially and merge results. To keep it simple we are not using async libraries.
+    foreach ( $requests as $req ) {
+        $cache_key = 'csl_remote_' . md5( $req['url'] );
+        $data      = get_transient( $cache_key );
+
+        if ( false === $data ) {
+            $response = wp_remote_get( $req['url'], $req['args'] );
+            if ( is_wp_error( $response ) ) {
+                continue;
+            }
+            $code = wp_remote_retrieve_response_code( $response );
+            if ( 200 !== $code ) {
+                continue;
+            }
+            $body = wp_remote_retrieve_body( $response );
+            $data = json_decode( $body, true );
+            if ( is_array( $data ) ) {
+                set_transient( $cache_key, $data, 30 * MINUTE_IN_SECONDS );
+            } else {
+                $data = [];
+            }
+        }
+
+        if ( is_array( $data ) ) {
+            foreach ( $data as $item ) {
+                // Add site information.
+                $item['site'] = parse_url( $req['url'], PHP_URL_HOST );
+                $results[] = $item;
+            }
+        }
+    }
+
+    return $results;
+}
+

--- a/cross-site-linker/inc/internal.php
+++ b/cross-site-linker/inc/internal.php
@@ -1,0 +1,44 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register internal REST route to fetch cross-site suggestions for the editor.
+ */
+function csl_register_internal_route() {
+    register_rest_route( 'csl/v1', '/suggestions', [
+        'methods'             => 'GET',
+        'callback'            => 'csl_handle_suggestions_request',
+        'permission_callback' => function() {
+            return current_user_can( 'edit_posts' );
+        },
+        'args' => [
+            'title' => [
+                'required' => true,
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+        ],
+    ] );
+}
+add_action( 'rest_api_init', 'csl_register_internal_route' );
+
+/**
+ * Handle suggestions request.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response
+ */
+function csl_handle_suggestions_request( WP_REST_Request $request ) {
+    $title     = sanitize_text_field( $request['title'] );
+    $results   = csl_get_cross_site_suggestions( $title );
+
+    // Filter out results pointing back to the current site.
+    $home = parse_url( home_url(), PHP_URL_HOST );
+    $results = array_filter( $results, function( $item ) use ( $home ) {
+        return isset( $item['url'] ) && parse_url( $item['url'], PHP_URL_HOST ) !== $home;
+    } );
+
+    return new WP_REST_Response( array_values( $results ) );
+}
+

--- a/cross-site-linker/inc/provider.php
+++ b/cross-site-linker/inc/provider.php
@@ -1,0 +1,70 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register REST API route for searching posts.
+ */
+function csl_register_api_routes() {
+    register_rest_route( 'crosslinker/v1', '/posts', [
+        'methods'  => 'GET',
+        'callback' => 'csl_handle_search',
+        'args'     => [
+            'q' => [
+                'required' => true,
+                'sanitize_callback' => 'sanitize_text_field',
+            ],
+        ],
+        'permission_callback' => '__return_true',
+    ] );
+}
+add_action( 'rest_api_init', 'csl_register_api_routes' );
+
+/**
+ * Handle the search request.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response
+ */
+function csl_handle_search( WP_REST_Request $request ) {
+    $api_key_option = get_option( 'csl_api_key', '' );
+    if ( ! empty( $api_key_option ) ) {
+        $supplied_key = $request->get_header( 'X-API-KEY' );
+        if ( $supplied_key !== $api_key_option ) {
+            return new WP_REST_Response( [ 'error' => 'Unauthorized' ], 401 );
+        }
+    }
+
+    $query = sanitize_text_field( $request['q'] );
+
+    $cache_key = 'csl_' . md5( $query );
+    $cached    = get_transient( $cache_key );
+    if ( false !== $cached ) {
+        return new WP_REST_Response( $cached );
+    }
+
+    $args = [
+        's'              => $query,
+        'post_status'    => 'publish',
+        'posts_per_page' => 5,
+    ];
+
+    $wp_query = new WP_Query( $args );
+    $results  = [];
+
+    if ( $wp_query->have_posts() ) {
+        foreach ( $wp_query->posts as $post ) {
+            $results[] = [
+                'title'   => get_the_title( $post ),
+                'url'     => get_permalink( $post ),
+                'excerpt' => wp_trim_words( $post->post_excerpt ? $post->post_excerpt : $post->post_content, 20, '...' ),
+            ];
+        }
+    }
+
+    set_transient( $cache_key, $results, 30 * MINUTE_IN_SECONDS );
+
+    return new WP_REST_Response( $results );
+}
+

--- a/cross-site-linker/inc/settings.php
+++ b/cross-site-linker/inc/settings.php
@@ -1,0 +1,92 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register plugin settings.
+ */
+function csl_register_settings() {
+    register_setting( 'csl_options', 'csl_sites' );
+    register_setting( 'csl_options', 'csl_api_key' );
+
+    add_settings_section( 'csl_main', __( 'Cross-Site Linker Settings', 'csl' ), '__return_false', 'csl' );
+
+    add_settings_field( 'csl_api_key', __( 'API Key', 'csl' ), 'csl_api_key_field', 'csl', 'csl_main' );
+    add_settings_field( 'csl_sites', __( 'Sites', 'csl' ), 'csl_sites_field', 'csl', 'csl_main' );
+}
+add_action( 'admin_init', 'csl_register_settings' );
+
+/**
+ * Render API key field.
+ */
+function csl_api_key_field() {
+    $value = get_option( 'csl_api_key', '' );
+    echo '<input type="text" name="csl_api_key" value="' . esc_attr( $value ) . '" class="regular-text" />';
+    echo '<p class="description">' . esc_html__( 'Optional API key for protecting the public API.', 'csl' ) . '</p>';
+}
+
+/**
+ * Render sites field.
+ */
+function csl_sites_field() {
+    $sites = get_option( 'csl_sites', [] );
+    if ( ! is_array( $sites ) ) {
+        $sites = [];
+    }
+    echo '<div id="csl-sites-wrapper">';
+    foreach ( $sites as $index => $site ) {
+        echo '<div class="csl-site">';
+        echo '<input type="text" name="csl_sites[' . esc_attr( $index ) . '][name]" value="' . esc_attr( $site['name'] ) . '" placeholder="' . esc_attr__( 'Site Name', 'csl' ) . '" /> ';
+        echo '<input type="text" name="csl_sites[' . esc_attr( $index ) . '][url]" value="' . esc_attr( $site['url'] ) . '" placeholder="https://example.com" /> ';
+        echo '<input type="text" name="csl_sites[' . esc_attr( $index ) . '][key]" value="' . esc_attr( $site['key'] ) . '" placeholder="' . esc_attr__( 'API Key', 'csl' ) . '" /> ';
+        echo '<button class="button csl-remove-site" type="button">' . esc_html__( 'Remove', 'csl' ) . '</button>';
+        echo '</div>';
+    }
+    echo '</div>';
+    echo '<button class="button" id="csl-add-site" type="button">' . esc_html__( 'Add Site', 'csl' ) . '</button>';
+    echo '<p class="description">' . esc_html__( 'Manage the list of other WordPress sites for cross-linking.', 'csl' ) . '</p>';
+}
+
+/**
+ * Add settings page to admin menu.
+ */
+function csl_add_settings_page() {
+    add_options_page( __( 'Cross-Site Linker', 'csl' ), __( 'Cross-Site Linker', 'csl' ), 'manage_options', 'csl', 'csl_render_settings_page' );
+}
+add_action( 'admin_menu', 'csl_add_settings_page' );
+
+/**
+ * Render settings page.
+ */
+function csl_render_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Cross-Site Linker Settings', 'csl' ); ?></h1>
+        <form action="options.php" method="post">
+            <?php
+            settings_fields( 'csl_options' );
+            do_settings_sections( 'csl' );
+            submit_button();
+            ?>
+        </form>
+    </div>
+    <script>
+    (function($){
+        $('#csl-add-site').on('click', function(){
+            var index = $('#csl-sites-wrapper .csl-site').length;
+            $('#csl-sites-wrapper').append('<div class="csl-site">' +
+                '<input type="text" name="csl_sites['+index+'][name]" placeholder="Site Name" /> ' +
+                '<input type="text" name="csl_sites['+index+'][url]" placeholder="https://example.com" /> ' +
+                '<input type="text" name="csl_sites['+index+'][key]" placeholder="API Key" /> ' +
+                '<button class="button csl-remove-site" type="button">Remove</button>' +
+            '</div>');
+        });
+        $(document).on('click', '.csl-remove-site', function(){
+            $(this).parent('.csl-site').remove();
+        });
+    })(jQuery);
+    </script>
+    <?php
+}
+

--- a/cross-site-linker/js/contextual.js
+++ b/cross-site-linker/js/contextual.js
@@ -1,0 +1,60 @@
+(function(wp){
+    const { registerFormatType, toggleFormat } = wp.richText;
+    const { createElement, Fragment, useState } = wp.element;
+    const { RichTextToolbarButton } = wp.blockEditor;
+    const { Popover, TextControl } = wp.components;
+    const { __ } = wp.i18n;
+    const apiFetch = wp.apiFetch;
+
+    const name = 'csl/contextual-link';
+
+    const EditButton = ({ isActive, value, onChange }) => {
+        const [ show, setShow ] = useState( false );
+        const [ results, setResults ] = useState([]);
+        const [ query, setQuery ] = useState('');
+        const [ rect, setRect ] = useState();
+
+        const onToggle = () => {
+            const selection = window.getSelection();
+            if ( selection.rangeCount === 0 ) {
+                alert( __('Please select text first.', 'csl') );
+                return;
+            }
+            setRect( selection.getRangeAt(0).getBoundingClientRect() );
+            setShow( ! show );
+        };
+
+        const search = (q) => {
+            setQuery(q);
+            if ( ! q ) return;
+            apiFetch( { path: '/csl/v1/suggestions?title=' + encodeURIComponent(q) } ).then( res => setResults(res) );
+        };
+
+        const insert = ( url ) => {
+            onChange( toggleFormat( value, { type: name, attributes: { href: url } } ) );
+            setShow(false);
+        };
+
+        return createElement( Fragment, {},
+            createElement( RichTextToolbarButton, { icon: 'admin-links', title: __('Cross-Site Link', 'csl'), onClick: onToggle, isActive } ),
+            show && createElement( Popover, { position: 'bottom left', anchorRect: rect, onClose: ()=>setShow(false) },
+                createElement( TextControl, { value: query, onChange: search, placeholder: __('Search...', 'csl') } ),
+                createElement('div', {}, results.map( (r, i) =>
+                    createElement('p', { key: i },
+                        createElement('a', { href: '#', onClick:(e)=>{e.preventDefault();insert(r.url);} }, r.title + ' ('+r.site+')' )
+                    )
+                ))
+            )
+        );
+    };
+
+    registerFormatType( name, {
+        title: __('Cross-Site Link', 'csl'),
+        tagName: 'a',
+        className: null,
+        edit: EditButton,
+        attributes: {
+            href: 'href'
+        }
+    } );
+})(window.wp);

--- a/cross-site-linker/js/editor.js
+++ b/cross-site-linker/js/editor.js
@@ -1,0 +1,46 @@
+(function(wp){
+    const { registerPlugin } = wp.plugins;
+    const { PluginSidebar } = wp.editPost;
+    const { PanelBody, Button } = wp.components;
+    const { useSelect } = wp.data;
+    const { Fragment, useState, useEffect } = wp.element;
+    const { __ } = wp.i18n;
+    const apiFetch = wp.apiFetch;
+
+    const CrossSiteSuggestions = () => {
+        const post = useSelect( select => select('core/editor').getCurrentPost(), [] );
+        const [ suggestions, setSuggestions ] = useState([]);
+
+        useEffect( () => {
+            if ( ! post ) return;
+            const keyword = post.title.rendered || '';
+            if ( ! keyword ) return;
+            apiFetch( { path: '/csl/v1/suggestions?title=' + encodeURIComponent( keyword ) } ).then( res => {
+                setSuggestions( res );
+            });
+        }, [ post ] );
+
+        const insertLink = ( url, title ) => {
+            const content = post.content.raw + '\n<a href="'+url+'">'+title+'</a>';
+            wp.data.dispatch('core/editor').editPost({ content: content });
+        };
+
+        return wp.element.createElement( PanelBody, { title: __('Cross-Site Suggestions', 'csl'), initialOpen: true },
+            suggestions.map( (s, i) => wp.element.createElement( Fragment, { key: i },
+                wp.element.createElement('p', {},
+                    wp.element.createElement('a', { href: s.url, target: '_blank' }, s.title),
+                    ' (' + s.site + ')'
+                ),
+                wp.element.createElement(Button, { isSecondary: true, onClick: () => insertLink(s.url, s.title) }, __('Insert', 'csl') )
+            ))
+        );
+    };
+
+    const PluginSidebarCrossSite = () => {
+        return wp.element.createElement( PluginSidebar, { name: 'csl-sidebar', title: __('Cross-Site Suggestions', 'csl') },
+            wp.element.createElement( CrossSiteSuggestions, null )
+        );
+    };
+
+    registerPlugin( 'csl-sidebar', { render: PluginSidebarCrossSite } );
+})(window.wp);


### PR DESCRIPTION
## Summary
- implement CrossSiteLinker plugin with provider and consumer roles
- expose `/wp-json/crosslinker/v1/posts` API with optional key protection and caching
- add settings page for managing remote sites
- add Gutenberg sidebar and contextual link toolbar

## Testing
- `php -l cross-site-linker/cross-site-linker.php`
- `php -l cross-site-linker/inc/provider.php`
- `php -l cross-site-linker/inc/settings.php`
- `php -l cross-site-linker/inc/client.php`
- `php -l cross-site-linker/inc/internal.php`


------
https://chatgpt.com/codex/tasks/task_e_687892be3b0c832b866192d922fe6e3a